### PR TITLE
Add release workflow for CurseForge and WoWInterface

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: Release
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: BigWigsMods/packager@v2
+        with:
+          args: -d
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -1,0 +1,3 @@
+package-as: TalentPlanner
+changelog-type: git
+changelog-length: 10


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow triggered on version tags (`v*`)
- Uses BigWigsMods/packager to build and upload to CurseForge and WoWInterface
- Adds `.pkgmeta` for package configuration with git-based changelog

## Usage
Bump version in TOC files, commit, tag (`git tag v4.1.0`), and push with `--tags`. The workflow handles the rest.