### PR TITLE
Remove dry-run flag from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: BigWigsMods/packager@v2
-        with:
-          args: -d
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}


### PR DESCRIPTION
The release workflow was using the -d (dry-run) flag, so it packaged but never uploaded to CurseForge or WoWInterface.