### PR TITLE
Add nightly Wowhead data update workflow

### DIFF
--- a/.github/workflows/update-wowhead-data.yml
+++ b/.github/workflows/update-wowhead-data.yml
@@ -1,0 +1,64 @@
+name: Update Wowhead Data
+
+on:
+  schedule:
+    - cron: "0 6 * * *"  # 6 AM UTC daily
+  workflow_dispatch:       # allow manual trigger
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Set up branch
+        run: |
+          BRANCH="auto/update-wowhead-data"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git ls-remote --exit-code origin "$BRANCH" > /dev/null 2>&1; then
+            git fetch origin "$BRANCH"
+          fi
+          git checkout -B "$BRANCH" origin/main
+
+      - name: Generate Classic data
+        run: uv run --project tools tools/generate_wowhead_data.py classic --fetch Importers/WowheadData_Classic.lua
+
+      - name: Generate TBC data
+        run: uv run --project tools tools/generate_wowhead_data.py tbc --fetch Importers/WowheadData_TBC.lua
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet Importers/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push and open PR
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="auto/update-wowhead-data"
+          git add Importers/WowheadData_Classic.lua Importers/WowheadData_TBC.lua
+          git commit -m "Update Wowhead talent data"
+          git push origin "$BRANCH" --force
+
+          EXISTING=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [ -z "$EXISTING" ]; then
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "Update Wowhead talent data" \
+              --body "Automated update of Wowhead talent calculator data for Classic and TBC.
+
+          This PR was created by a scheduled workflow. Review the diff to see what changed."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .release/
 .DS_Store
+tools/.venv/

--- a/tools/generate_wowhead_data.py
+++ b/tools/generate_wowhead_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --project tools
 """
 Generates WowheadData Lua files from Wowhead talent calculator data.
 

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "talent-planner-tools"
+version = "1.0.0"
+description = "Tools for generating Talent Planner addon data"
+requires-python = ">=3.11"
+dependencies = []
+

--- a/tools/uv.lock
+++ b/tools/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "talent-planner-tools"
+version = "1.0.0"
+source = { virtual = "." }


### PR DESCRIPTION
## Summary
- Set up a `uv` project for Python tools with proper dependency management (`pyproject.toml` + `uv.lock`)
- Add a nightly GitHub Actions workflow that fetches the latest Classic and TBC talent data from Wowhead, and opens a PR if anything changed
- The workflow reuses the same branch (`auto/update-wowhead-data`) so repeated runs update the existing PR rather than creating new ones