### PR TITLE
Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: BigWigsMods/packager@v2
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}

--- a/.github/workflows/update-wowhead-data.yml
+++ b/.github/workflows/update-wowhead-data.yml
@@ -13,9 +13,9 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
 
       - name: Set up branch
         run: |


### PR DESCRIPTION
Bump actions/checkout v4 → v6 and astral-sh/setup-uv v6 → v7 to resolve Node.js 20 deprecation warnings before the June 2026 cutoff.