### PR TITLE
Talent Planner 4.2.1: Full rewrite with multi-class support, localization, and Wowhead integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .release/
 .DS_Store
 tools/.venv/
+__pycache__/
+*.pyc

--- a/Importers/Wowhead.lua
+++ b/Importers/Wowhead.lua
@@ -231,7 +231,7 @@ function ts.WowheadTalents.GetTalents(talentString)
     local pointsSpent = 0
     for i = 1, talentStringLength, 1 do
         local encodedId = strsub(talentString, i, i)
-        if strbyte(encodedId) <= 50 then
+        if strfind("012", encodedId, 1, true) then
             currentTab = tonumber(encodedId)
         else
             local talentIndex, entry, err, isMaxRank =

--- a/Importers/Wowhead.lua
+++ b/Importers/Wowhead.lua
@@ -181,6 +181,19 @@ local function HasTalentOrder(encodedString, flavorMeta)
     return false
 end
 
+local function GetMaxRankForEntry(tabIndex, talentIndex, entry)
+    if (entry and type(entry.ranks) == "table" and #entry.ranks > 0) then
+        return #entry.ranks
+    end
+
+    local _, _, _, _, _, maxRank = GetTalentInfo(tabIndex, talentIndex)
+    return maxRank
+end
+
+local function GetTalentCounterKey(tabIndex, talentIndex)
+    return tostring(tabIndex) .. ":" .. tostring(talentIndex)
+end
+
 function ts.WowheadTalents.GetTalents(talentString)
     local rawTalentString = NormalizeTalentString(talentString)
     if not rawTalentString then
@@ -228,7 +241,10 @@ function ts.WowheadTalents.GetTalents(talentString)
             end
             local ranks = entry and entry.ranks
             if isMaxRank then
-                local _, _, _, _, _, maxRank = GetTalentInfo(currentTab + 1, talentIndex)
+                local maxRank = GetMaxRankForEntry(currentTab + 1, talentIndex, entry)
+                if not maxRank or maxRank < 1 then
+                    return nil, classToken, "MAPPING_FAILED"
+                end
                 for j = 1, maxRank, 1 do
                     pointsSpent = pointsSpent + 1
                     tinsert(talents, {
@@ -241,8 +257,9 @@ function ts.WowheadTalents.GetTalents(talentString)
                 end
             else
                 pointsSpent = pointsSpent + 1
-                talentCounter[talentIndex] = (talentCounter[talentIndex] or 0) + 1
-                local rank = talentCounter[talentIndex]
+                local counterKey = GetTalentCounterKey(currentTab + 1, talentIndex)
+                talentCounter[counterKey] = (talentCounter[counterKey] or 0) + 1
+                local rank = talentCounter[counterKey]
                 tinsert(talents, {
                     tab = currentTab + 1,
                     index = talentIndex,

--- a/README_WOWINTERFACE.txt
+++ b/README_WOWINTERFACE.txt
@@ -1,0 +1,53 @@
+[SIZE="7"]Talent Planner[/SIZE]
+
+Talent Planner is a WoW AddOn for Classic Anniversary Edition and Burning Crusade Classic that displays a planned talent order next to the in-game talent window while you level.
+
+Import a talent sequence from a Wowhead calculator URL, save multiple sequences per character, and load the one you want to follow in-game.
+
+[SIZE="7"]Supports[/SIZE]
+
+[LIST]
+[*]Wowhead Classic talent calculator URLs
+[*]Wowhead TBC talent calculator URLs
+[*]Blizzard talent UI
+[*]Talented addon integration
+[/LIST]
+
+[SIZE="7"]In-Game Previews[/SIZE]
+
+[IMG]https://i.imgur.com/elwqFaH.jpeg[/IMG]
+
+[SIZE="7"]How To Use[/SIZE]
+
+[SIZE="5"]Add a Wowhead Talent Sequence[/SIZE]
+
+[LIST]
+[*]Build your talent sequence in the Wowhead calculator for your game version:
+  - Classic Era / Anniversary: use the Classic calculator
+  - Burning Crusade Classic: use the TBC calculator
+[*]Ensure that Talent Order is enabled in Wowhead. You must expand the Talent Order panel and keep it active, or Wowhead may not preserve the point-by-point sequence in the URL.
+[*]Copy the entire Wowhead talent calculator URL.
+[*]In-game, open your Talent window and click Talent Planner >>
+[*]Click Import
+[*]Paste the Wowhead talent calculator URL
+[*]Name the sequence and press Enter
+[*]Click Load on that saved sequence to make it active
+[*]Spend points as you level using the sequence shown beside the talent window
+[/LIST]
+
+[IMG]https://i.imgur.com/dZAMbix.png[/IMG]
+[IMG]https://i.imgur.com/3BZAal9.png[/IMG]
+
+[SIZE="7"]Wowhead Import Coverage[/SIZE]
+
+TBC Wowhead imports use explicit class and tree mappings for all nine classes. Classic Wowhead support is also available.
+
+The importer resolves in-game talent indices dynamically with GetTalentInfo, making it robust across Classic/TBC tree differences.
+
+[SIZE="7"]Origins[/SIZE]
+
+This AddOn is a fork of the original [URL="https://www.curseforge.com/wow/addons/talent-sequence/"]Talent Sequence[/URL] AddOn, updated for current Classic clients with flavor-specific TOCs, improved Wowhead import handling, and compatibility fixes for current Classic UI behavior.
+
+[SIZE="7"]Issues and Feedback[/SIZE]
+
+Found a bug or have a feature request? Please [URL="https://github.com/mikeacjones/TalentPlanner/issues"]open an issue on GitHub[/URL].

--- a/TalentPlanner_TBC.toc
+++ b/TalentPlanner_TBC.toc
@@ -1,6 +1,6 @@
 ## Interface: 20505
 ## Title: Talent Planner
-## Version: 4.2.0
+## Version: 4.2.1
 ## Author: Moregelen, Sveng
 ## Notes: Shows what order you should spend talent points in, based on Wowhead talent calculators. Compatible with Burning Crusade Classic.
 ## SavedVariables: TalentPlannerAccountSavedSequences, TalentPlannerAccountCollapsedClasses, TalentPlannerAccountNextSequenceId

--- a/TalentPlanner_Vanilla.toc
+++ b/TalentPlanner_Vanilla.toc
@@ -1,6 +1,6 @@
 ## Interface: 11508
 ## Title: Talent Planner
-## Version: 4.2.0
+## Version: 4.2.1
 ## Author: Moregelen, Sveng
 ## Notes: Shows what order you should spend talent points in, based on Wowhead talent calculators. Compatible with WoW Classic Anniversary Edition.
 ## SavedVariables: TalentPlannerAccountSavedSequences, TalentPlannerAccountCollapsedClasses, TalentPlannerAccountNextSequenceId

--- a/UI/Tracker.lua
+++ b/UI/Tracker.lua
@@ -215,7 +215,6 @@ function ts.CreateMainFrame()
     local cfg = ts.FrameConfig
     local talentFrame = cfg.talentFrameName
     local mainFrame = CreateFrame("Frame", nil, _G[talentFrame], BackdropTemplateMixin and "BackdropTemplate")
-    mainFrame:SetPoint("CENTER")
     mainFrame:SetSize(128, 128)
     mainFrame:SetPoint(cfg.trackerAnchors[1][1], talentFrame, cfg.trackerAnchors[1][2], cfg.trackerAnchors[1][3], cfg.trackerAnchors[1][4])
     mainFrame:SetPoint(cfg.trackerAnchors[2][1], talentFrame, cfg.trackerAnchors[2][2], cfg.trackerAnchors[2][3], cfg.trackerAnchors[2][4])


### PR DESCRIPTION
## Summary

Bug fixes and minor improvements for v4.2.1.

### Wowhead importer fixes
- Fix rank counter using talent index alone as key, which caused incorrect rank tracking when the same talent index appeared in different trees. Now uses a composite `tab:index` key
- Add `GetMaxRankForEntry` helper that resolves max rank from WowheadData first, falling back to `GetTalentInfo` — fixes max-rank expansion for cross-class imports where `GetTalentInfo` returns nil
- Add validation for max rank resolution, returning `MAPPING_FAILED` instead of silently producing broken sequences
- Use explicit `strfind("012", ...)` check for tab separators instead of `strbyte <= 50` for clarity

### UI fix
- Remove redundant `SetPoint("CENTER")` anchor on the tracker frame that conflicted with the two corner anchors already defining its layout

### Other
- Add `README_WOWINTERFACE.txt` for WoWInterface listing
- Add `__pycache__/` and `*.pyc` to `.gitignore`
- Bump version to 4.2.1